### PR TITLE
Add field skipping

### DIFF
--- a/annotationprocessor/src/main/java/com/quarkworks/android/realmtypesafequery/annotationprocessor/AnnotationProcessor.kt
+++ b/annotationprocessor/src/main/java/com/quarkworks/android/realmtypesafequery/annotationprocessor/AnnotationProcessor.kt
@@ -1,6 +1,8 @@
 package com.quarkworks.android.realmtypesafequery.annotationprocessor
 
 import com.google.auto.service.AutoService
+import com.quarkworks.android.realmtypesafequery.annotations.SkipGenerationOfRealmFieldName
+import com.quarkworks.android.realmtypesafequery.annotations.SkipGenerationOfRealmField
 import com.quarkworks.android.realmtypesafequery.annotations.GenerateRealmFieldNames
 import com.quarkworks.android.realmtypesafequery.annotations.GenerateRealmFields
 import com.squareup.javapoet.FieldSpec
@@ -84,6 +86,7 @@ class AnnotationProcessor : AbstractProcessor() {
                 // ignore static and @Ignore fields
                 if (realmField.modifiers.contains(Modifier.STATIC)) continue
                 if (realmField.isAnnotatedWith(Ignore::class.java)) continue
+                if (realmField.isAnnotatedWith(SkipGenerationOfRealmFieldName::class.java)) continue
 
                 val name = realmField.simpleName.toString().toConstId()
 
@@ -172,7 +175,9 @@ class AnnotationProcessor : AbstractProcessor() {
 
             // ignore static and @Ignore fields
             val realmFieldClassFSpecs = variableElements.filter {
-                        !it.modifiers.contains(Modifier.STATIC) && !it.isAnnotatedWith(Ignore::class.java)
+                !it.modifiers.contains(Modifier.STATIC) &&
+                                !it.isAnnotatedWith(Ignore::class.java) &&
+                                !it.isAnnotatedWith(SkipGenerationOfRealmField::class.java)
             }.mapTo(LinkedList()) { makeFieldSpec(element, it) }
 
             val className = element.simpleName.toString() + "Fields"

--- a/annotations/src/main/java/com/quarkworks/android/realmtypesafequery/annotations/SkipGenerationOfRealmField.java
+++ b/annotations/src/main/java/com/quarkworks/android/realmtypesafequery/annotations/SkipGenerationOfRealmField.java
@@ -1,0 +1,14 @@
+package com.quarkworks.android.realmtypesafequery.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Created by berbschloe on 10/20/17.
+ */
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.SOURCE)
+public @interface SkipGenerationOfRealmField {}

--- a/annotations/src/main/java/com/quarkworks/android/realmtypesafequery/annotations/SkipGenerationOfRealmFieldName.java
+++ b/annotations/src/main/java/com/quarkworks/android/realmtypesafequery/annotations/SkipGenerationOfRealmFieldName.java
@@ -1,0 +1,14 @@
+package com.quarkworks.android.realmtypesafequery.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Created by berbschloe on 10/20/17.
+ */
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.SOURCE)
+public @interface SkipGenerationOfRealmFieldName {}


### PR DESCRIPTION
Allows for certain fields to be skipped when generating fields and field names.
See https://realm.io/docs/java/latest/#lists-of-primitives.
We need to allow some realm fields to be ignored until we have support for them.